### PR TITLE
Fix various bad memory operations revealed by Valgrind

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "SAGE"]
 	path = SAGE
 	url = https://github.com/AlisaMaas/llvm-sage.git
-	branch = no-qepcad-on-minmax
+	branch = valgrind

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "SAGE"]
 	path = SAGE
 	url = https://github.com/AlisaMaas/llvm-sage.git
-	branch = valgrind
+	branch = no-qepcad-on-minmax

--- a/Redefinition.cpp
+++ b/Redefinition.cpp
@@ -39,7 +39,7 @@ static bool IsRedefinable(Value *V) {
 
 static PHINode *CreateNamedPhi(Value *V, Twine Prefix,
                                BasicBlock::iterator Position) {
-  Twine Name(V->hasName() ? Prefix + "." + V->getName() : Prefix);
+  const auto Name = (V->hasName() ? Prefix + "." + V->getName() : Prefix).str();
   return PHINode::Create(V->getType(), 1, Name, Position);
 }
 

--- a/SymbolicRangeAnalysis.cpp
+++ b/SymbolicRangeAnalysis.cpp
@@ -259,10 +259,8 @@ std::string SymbolicRangeAnalysis::makeName(Function *F, Value *V) {
     auto Name = (F->getName() + Twine("_") + V->getName()).str();
     std::replace(Name.begin(), Name.end(), '.', '_');
     return Name;
-  } else {
-    auto Name = F->getName() + Twine("_") + Twine(Temp++);
-    return Name.str();
-  }
+  } else
+    return (F->getName() + Twine("_") + Twine(Temp++)).str();
 }
 
 void SymbolicRangeAnalysis::setName(Value *V, std::string Name) {

--- a/SymbolicRangeAnalysis.cpp
+++ b/SymbolicRangeAnalysis.cpp
@@ -460,8 +460,9 @@ void SymbolicRangeAnalysis::reset(Function *F) {
 void SymbolicRangeAnalysis::iterate(Function *F) {
   DEBUG(dbgs() << "SRA: Iterate\n");
   while (!Worklist_.empty()) {
-    auto Next = Worklist_.begin(); Worklist_.erase(Next);
+    auto Next = Worklist_.begin();
     Instruction *I = Next->second;
+    Worklist_.erase(Next);
     if (Fn_.count(I) && !Evaled_.count(I)) {
       Evaled_.insert(I);
       setState(I, Fn_[I]());


### PR DESCRIPTION
These fixes address three bad memory operations. Two stem from unsafe use of `llvm::Twine` instances across statements. One involves use of an invalidated iterator. This merge also picks up an updated version of the `llvm-sage` submodule that already includes a Valgrind-directed leak fix.
